### PR TITLE
Automatically read runtime from runtime.c

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,9 +42,6 @@ jobs:
           eval $(opam env)
           dune build
 
-      - name: Build Runtime
-        run: gcc -c runtime.c -o runtime.o
-
       - name: Simple Test
         run: |
           eval $(opam env)

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -25,16 +25,11 @@ let compile_to_file (program: string): unit =
     output_string file (compile (parse program));
     close_out file
 
-let check_runtime (): unit =
-    if not( Sys.file_exists "runtime.o") then
-        raise (Failure "No compiled runtime found.\nDid you compile it? Try:\n> gcc -c runtime.c -o runtime.o")
-
 let compile_and_run (program: string): string =
     compile_to_file program;
-    check_runtime();
     let format = (if Asm.macos then "macho64" else "elf64") in
     ignore (Unix.system ("nasm program.s -f " ^ format ^ " -o program.o"));
-    ignore (Unix.system "gcc program.o runtime.o -o program");
+    ignore (Unix.system "gcc program.o runtime.c -o program");
     let inp = Unix.open_process_in "./program" in
     let r = input_line inp in
     close_in inp; r


### PR DESCRIPTION
I just figured that removing this extra step would make things a little smoother. I think modern C compilers can take in any arbitrary data, so passing in both a C file and an object file should work.

Tested this on both macOS and Linux.