### PR TITLE
Add more type checking

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -171,6 +171,7 @@ let rec compile_exp (defns : defn list) (tab : int symtab) (stack_index : int)
       @ [Add (Reg Rax, operand_of_num 1)]
   | Lst [Sym "sub1"; arg] ->
       compile_exp defns tab stack_index arg false
+      @ ensure_num (Reg Rax)
       @ [Sub (Reg Rax, operand_of_num 1)]
   | Lst [Sym "if"; test_exp; then_exp; else_exp] ->
       let else_label = Util.gensym "else" in

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -39,6 +39,12 @@ let ensure_num (op: operand) : directive list =
     Cmp (Reg R8, Imm num_tag);
     Jnz "error"]
 
+let ensure_bool (op: operand) : directive list =
+  [ Mov (Reg R8, op);
+    And (Reg R8, Imm bool_mask);
+    Cmp (Reg R8, Imm bool_tag);
+    Jnz "error"]
+
 let ensure_pair (op : operand) : directive list =
   [ Mov (Reg R8, op)
   ; And (Reg R8, Imm heap_mask)
@@ -177,6 +183,7 @@ let rec compile_exp (defns : defn list) (tab : int symtab) (stack_index : int)
       let else_label = Util.gensym "else" in
       let continue_label = Util.gensym "continue" in
       compile_exp defns tab stack_index test_exp false
+      @ ensure_bool (Reg Rax)
       @ [Cmp (Reg Rax, operand_of_bool false); Jz else_label]
       @ compile_exp defns tab stack_index then_exp is_tail
       @ [Jmp continue_label] @ [Label else_label]

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -183,28 +183,36 @@ let rec compile_exp (defns : defn list) (tab : int symtab) (stack_index : int)
       @ [Label continue_label]
   | Lst [Sym "+"; e1; e2] ->
       compile_exp defns tab stack_index e1 false
+      @ ensure_num (Reg Rax)
       @ [Mov (stack_address stack_index, Reg Rax)]
       @ compile_exp defns tab (stack_index - 8) e2 false
+      @ ensure_num (Reg Rax)
       @ [Mov (Reg R8, stack_address stack_index)]
       @ [Add (Reg Rax, Reg R8)]
   | Lst [Sym "-"; e1; e2] ->
       compile_exp defns tab stack_index e1 false
+      @ ensure_num (Reg Rax)
       @ [Mov (stack_address stack_index, Reg Rax)]
       @ compile_exp defns tab (stack_index - 8) e2 false
+      @ ensure_num (Reg Rax)
       @ [Mov (Reg R8, Reg Rax)]
       @ [Mov (Reg Rax, stack_address stack_index)]
       @ [Sub (Reg Rax, Reg R8)]
   | Lst [Sym "="; e1; e2] ->
       compile_exp defns tab stack_index e1 false
+      @ ensure_num (Reg Rax)
       @ [Mov (stack_address stack_index, Reg Rax)]
       @ compile_exp defns tab (stack_index - 8) e2 false
+      @ ensure_num (Reg Rax)
       @ [Mov (Reg R8, stack_address stack_index)]
       @ [Cmp (Reg Rax, Reg R8)]
       @ zf_to_bool
   | Lst [Sym "<"; e1; e2] ->
       compile_exp defns tab stack_index e1 false
+      @ ensure_num (Reg Rax)
       @ [Mov (stack_address stack_index, Reg Rax)]
       @ compile_exp defns tab (stack_index - 8) e2 false
+      @ ensure_num (Reg Rax)
       @ [Mov (Reg R8, stack_address stack_index)]
       @ [Cmp (Reg R8, Reg Rax)]
       @ lf_to_bool


### PR DESCRIPTION
- For `+`, `-`, `=`, `<`, ensure both operands are number 
- Ensure operand of `sub1` is number 
- Add `ensure_bool` gadgets, and apply it to check the test expression of `if`